### PR TITLE
fix: fast fail if no fetched binaries

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -135,7 +135,7 @@ export async function need(opts: NeedOptions) {
     }
   }
 
-  throw new Error('Could not find binaries in PKG_CACHE_PATH nor default USER/.pkg-cache. Amplify's fork requires that cache with binaries is prepared before executing this step.');
+  throw new Error("Could not find binaries in PKG_CACHE_PATH nor default USER/.pkg-cache. Amplify's fork requires that cache with binaries is prepared before executing this step.");
 
   if (!forceFetch) {
     if (await exists(built)) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -135,7 +135,7 @@ export async function need(opts: NeedOptions) {
     }
   }
 
-  throw new Error("Could not fetch binary.");
+  throw new Error('Could not find binaries in PKG_CACHE_PATH nor default USER/.pkg-cache. Amplify's fork requires that cache with binaries is prepared before executing this step.');
 
   if (!forceFetch) {
     if (await exists(built)) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -135,6 +135,8 @@ export async function need(opts: NeedOptions) {
     }
   }
 
+  throw new Error("Could not fetch binary.");
+
   if (!forceFetch) {
     if (await exists(built)) {
       if (dryRun) return 'exists';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fast fail if no fetched binaries so that we do not use binary from remote or try to build our own.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
